### PR TITLE
Fixed syntax on Tukey window creation

### DIFF
--- a/plot_PSD/__init__.py
+++ b/plot_PSD/__init__.py
@@ -522,7 +522,7 @@ def plot_PSD(**kwargs):
         noverlap = round(Lsegm * overlap_perc/100)
 
         
-        win=sig.tukey(Lsegm,param)
+        win=sig.windows.tukey(Lsegm,param)
 
                 
        


### PR DESCRIPTION
Changed `win=sig.tukey(Lsegm,param)` into `win=sig.windows.tukey(Lsegm,param)`.

https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html

@vlahtin @Vahe4578 @Kovalevy @spelmaa2 @Kovalevy 